### PR TITLE
Open function must return true / false -> fixed (fix #19)

### DIFF
--- a/src/OptimisticSessionHandler.php
+++ b/src/OptimisticSessionHandler.php
@@ -84,7 +84,7 @@ class  OptimisticSessionHandler extends \SessionHandler
             $this->shutdownFunctionRegistered = true;
         }
         $this->sessionBeforeSessionStart = isset($_SESSION) ? $_SESSION : [];
-        parent::open($save_path, $name);
+        return parent::open($save_path, $name);
     }
 
     /**


### PR DESCRIPTION
As specified at :
http://php.net/manual/fr/sessionhandlerinterface.open.php

Open function must return true / false ; so we return the value of the SessionHandler's open function.
