### PR TITLE
Updated to be compatible with PHP 7.1 and 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Then you can start the session as usual
 
     session_start();
 
+Or for PHP versions >= 7.0
+
+    session_start(['read_and_close' => true]);
+
 Then the `$_SESSION` array is accessible.
 
 You can configure rules for managing conflicts. Just add element to the class parameter $conflictRules.

--- a/tests/fixtures/double_session_start.php
+++ b/tests/fixtures/double_session_start.php
@@ -15,13 +15,13 @@ $waitBeforeQuit = isset($_GET['waitBeforeQuit']) ? $_GET['waitBeforeQuit'] : 0;
 
 sleep($waitBeforeStart);
 
-session_start();
+session_start(['read_and_close' => true]);
 
 if ($a) {
     $_SESSION['a'] = $a;
 }
 
 // Second session start... that should not change the session.
-@session_start();
+@session_start(['read_and_close' => true]);
 
 sleep($waitBeforeQuit);

--- a/tests/fixtures/get_values.php
+++ b/tests/fixtures/get_values.php
@@ -10,7 +10,7 @@ $waitBeforeStart = isset($_GET['waitBeforeStart']) ? $_GET['waitBeforeStart'] : 
 $waitBeforeQuit = isset($_GET['waitBeforeQuit']) ? $_GET['waitBeforeQuit'] : 0;
 
 sleep($waitBeforeStart);
-session_start();
+session_start(['read_and_close' => true]);
 
 echo 'a='.(isset($_SESSION['a']) ? $_SESSION['a'] : 'null')."\n";
 echo 'b='.(isset($_SESSION['b']) ? $_SESSION['b'] : 'null')."\n";

--- a/tests/fixtures/set_value.php
+++ b/tests/fixtures/set_value.php
@@ -13,7 +13,7 @@ $waitBeforeQuit = isset($_GET['waitBeforeQuit']) ? $_GET['waitBeforeQuit'] : 0;
 
 sleep($waitBeforeStart);
 
-session_start();
+session_start(['read_and_close' => true]);
 
 if ($a) {
     $_SESSION['a'] = $a;

--- a/tests/fixtures/start-unregister-and-restart.php
+++ b/tests/fixtures/start-unregister-and-restart.php
@@ -9,11 +9,11 @@ use Mouf\Utils\Session\SessionHandler\OptimisticSessionHandler;
 
 session_set_save_handler(new OptimisticSessionHandler(), true);
 
-session_start();
+session_start(['read_and_close' => true]);
 
 $_SESSION['mouf'] = 'mouf';
 
 session_set_save_handler(new \SessionHandler(), true);// unset the OptimisticSessionHandler
 
 // Second session start... that should trigger an Exception.
-@session_start();
+@session_start(['read_and_close' => true]);


### PR DESCRIPTION
I've fixed some problems that prevented me from using the optimistic session handler in PHP versions 7.1 and 7.2.

1. Because PHP now prevents recursive calls to the user defined handler it is no longer possible to call session_write_close() from within the read() method. However since 7.0 you can pass the read_and_close option to session_start(), which closes the session immediately after reading it. This makes the call to session_write_close() unnecessary.

2. read() must return an empty string if there is no session data, not false.

3. After headers have been sent session_start() will not start a new session unless the config settings tell it that sessions do not need to send headers. I added calls to ini_set() before session_start() in secureSessionStart() to change the config settings temporarily so that session_start() will run.